### PR TITLE
Add Questionnaire Sequelize model and migrations

### DIFF
--- a/backend/server/migrations/0003-create-questionnaire.js
+++ b/backend/server/migrations/0003-create-questionnaire.js
@@ -1,0 +1,41 @@
+'use strict';
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('Questionnaires', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER,
+      },
+      name: {
+        type: Sequelize.STRING,
+      },
+      description: {
+        type: Sequelize.STRING,
+      },
+      isPublic: {
+        type: Sequelize.BOOLEAN,
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      user_id: {
+        type: Sequelize.STRING,
+        references: {
+          model: 'Users',
+          key: 'id',
+          as: 'user_id'
+        }
+      },
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('Questionnaires');
+  }
+}

--- a/backend/server/migrations/0004-create-experiment-questionnaire.js
+++ b/backend/server/migrations/0004-create-experiment-questionnaire.js
@@ -1,0 +1,26 @@
+'use strict';
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('ExperimentQuestionnaire', {
+      experiment_id: {
+        type: Sequelize.INTEGER,
+        references: {
+          model: 'Experiments',
+          key: 'id',
+          as: 'experiment_id',
+        },
+      },
+      questionnaire_id: {
+        type: Sequelize.INTEGER,
+        references: {
+          model: 'Questionnaires',
+          key: 'id',
+          as: 'questionnaire_id',
+        },
+      },
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('ExperimentQuestionnaire');
+  }
+};

--- a/backend/server/models/experiment.js
+++ b/backend/server/models/experiment.js
@@ -33,6 +33,7 @@ module.exports = (sequelize, DataTypes) => {
         as: 'user',
         onDelete: 'CASCADE',
       })
+    Experiment.belongsToMany(models.Questionnaire, {through: 'ExperimentQuestionnaire'});
   }
 
   return Experiment;

--- a/backend/server/models/questionnaire.js
+++ b/backend/server/models/questionnaire.js
@@ -1,0 +1,33 @@
+'use strict';
+module.exports = (sequelize, DataTypes) => {
+  var Questionnaire = sequelize.define('Questionnaire', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: DataTypes.INTEGER,
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    description: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    isPublic: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+    },
+  }, {});
+
+  Questionnaire.associate = function (models) {
+    Questionnaire.belongsTo(models.User, {
+      foreignKey: 'user_id',
+      as: 'user',
+      onDelete: 'CASCADE',
+    });
+    Questionnaire.belongsToMany(models.Experiment, {through: 'ExperimentQuestionnaire'});
+  }
+  return Questionnaire;
+};


### PR DESCRIPTION
Add Questionnaire model and migrations for the CSUQ questionnaire. 

Subsequent PRs will include the seeds and the rest of the models pertaining to the CSUQ.

The structure will be the following:
A Questionnaire can belong to multiple Experiments (it must be public or belong to the Experiment's user). (many-to-many relation)
A Questionnaire has multiple Questions (for now, all Likert-scale type). (1-to-many relation).
A Questionnaire has multiple Responses. (1-to-many relation).
A Response has many Questions. (many-to-many relation).

This way we can reuse questionnaires in different experiments and even have some preexisting ones.