### PR TITLE
Create Participant model and migration

### DIFF
--- a/backend/server/migrations/0008-create-participant.js
+++ b/backend/server/migrations/0008-create-participant.js
@@ -1,0 +1,24 @@
+'use strict';
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('Participants', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER,
+      },
+      experiment_id: {
+        type: Sequelize.INTEGER,
+        references: {
+          model: 'Experiments',
+          key: 'id',
+          as: 'experiment_id'
+        }
+      },
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('Participants');
+  }
+}

--- a/backend/server/models/participant.js
+++ b/backend/server/models/participant.js
@@ -1,0 +1,23 @@
+'use strict';
+module.exports = (sequelize, DataTypes) => {
+  var Participant = sequelize.define('Participant', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: DataTypes.INTEGER,
+    },
+    // There will be further information here, but as for now this solely serves
+    // the purpose of bridging a QuestionnaireResponse with an 
+    // Experiment.
+  }, {});
+
+  Participant.associate = function (models) {
+    Participant.belongsTo(models.Experiment, {
+      foreignKey: 'experiment_id',
+      as: 'experiment',
+      onDelete: 'CASCADE',
+    });
+  }
+  return Participant;
+};


### PR DESCRIPTION
Add the Participant model and migration.

The vision here is that a Participant links not only the QuestionnaireResponse with the respective Experiment, but also functions as the entity that responds the Experiment's questions themselves.

Further fields should be defined later on, as they will be needed for demographic purposes (e.g. age range, gender, etc.).