### PR TITLE
Fix linting errors on frontend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,3 +61,5 @@ script:
 - cd ../frontend/
 # Execute the Angular frontend tests a single time by setting the 'watch' flag to false.
 - ng test --watch=false
+# Execute the Angular linting script.
+- ng lint

--- a/frontend/src/app/components/authentication/login/login.component.spec.ts
+++ b/frontend/src/app/components/authentication/login/login.component.spec.ts
@@ -47,15 +47,15 @@ describe('LoginComponent', () => {
     expect(component.password).toEqual('', 'The password field is not empty.');
   }));
 
-  it("The login() method should be called if the 'Log in' button is clicked", async(() => {
-    spyOn(component, "login");
+  it('The login() method should be called if the \'Log in\' button is clicked', async(() => {
+    spyOn(component, 'login');
     htmlElement = fixture.debugElement.query(By.css('.btn.rounded-btn')).nativeElement;
     htmlElement.click();
     expect(component.login).toHaveBeenCalled();
   }));
 
-  it("The goToSignup() method should be called if the 'Don't have an account yet? Register here!' button is clicked", async(() => {
-    spyOn(component, "goToSignup");
+  it('The goToSignup() method should be called if the \'Don\'t have an account yet? Register here!\' button is clicked', async(() => {
+    spyOn(component, 'goToSignup');
     htmlElement = fixture.debugElement.query(By.css('.btn.signup')).nativeElement;
     htmlElement.click();
     expect(component.goToSignup).toHaveBeenCalled();

--- a/frontend/src/app/components/experiments/experiment-create/experiment-create.component.spec.ts
+++ b/frontend/src/app/components/experiments/experiment-create/experiment-create.component.spec.ts
@@ -21,8 +21,8 @@ describe('ExperimentCreateComponent', () => {
     TestBed.configureTestingModule({
       declarations: [ExperimentCreateComponent],
       imports: [
-        RouterTestingModule, 
-        FormsModule, 
+        RouterTestingModule,
+        FormsModule,
         BrowserModule
       ],
       providers: [
@@ -52,7 +52,7 @@ describe('ExperimentCreateComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('The form should be valid', async(() => {  
+  it('The form should be valid', async(() => {
 
     expect(component.experiment.name).toEqual(null, 'The experiment name is not null');
     expect(component.experiment.description).toEqual(null, 'The experiment description is not null');
@@ -60,17 +60,17 @@ describe('ExperimentCreateComponent', () => {
     expect(component.experiment.endDate).toEqual(null, 'The experiment endDate is not null');
   }));
 
-  it("The createExperiment() method should be called if the 'Create Experiment' button is clicked", async(() => {
+  it('The createExperiment() method should be called if the \'Create Experiment\' button is clicked', async(() => {
 
-    spyOn(component, "createExperiment");
+    spyOn(component, 'createExperiment');
     htmlElement = fixture.debugElement.query(By.css('.btn.btn-success.pull-right')).nativeElement;
     htmlElement.click();
     expect(component.createExperiment).toHaveBeenCalled();
   }));
 
-  it("The listExperiments() method should be called if the 'Back' button is clicked", async(() => {
+  it('The listExperiments() method should be called if the \'Back\' button is clicked', async(() => {
 
-    spyOn(component, "listExperiments");
+    spyOn(component, 'listExperiments');
     htmlElement = fixture.debugElement.query(By.css('.btn.btn-lg.btn-danger')).nativeElement;
     htmlElement.click();
     expect(component.listExperiments).toHaveBeenCalled();

--- a/frontend/src/app/components/experiments/experiment-create/experiment-create.component.ts
+++ b/frontend/src/app/components/experiments/experiment-create/experiment-create.component.ts
@@ -6,7 +6,7 @@ import { User } from '../../../models/user';
 import { AuthService } from '../../../services/auth.service';
 import { Router, ActivatedRoute } from '@angular/router';
 import { ErrorHandlerService } from '../../../services/error-handler.service';
-import { BodyPart } from '../../../models/bodyPart';
+import { BodyPart } from '../../../models/body-part';
 
 @Component({
   selector: 'app-experiment-create',
@@ -17,7 +17,7 @@ export class ExperimentCreateComponent implements OnInit {
 
   experiment: Experiment;
   id: number;
-  bodyPart : BodyPart;
+  bodyPart: BodyPart;
 
   constructor(
     private errorHandler: ErrorHandlerService,

--- a/frontend/src/app/components/experiments/experiment-list/experiment-list.component.spec.ts
+++ b/frontend/src/app/components/experiments/experiment-list/experiment-list.component.spec.ts
@@ -44,9 +44,9 @@ describe('ExperimentListComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it("The createExperiment() method should be called if the 'Create Experiment' button is clicked", async(() => {
+  it('The createExperiment() method should be called if the \'Create Experiment\' button is clicked', async(() => {
 
-    spyOn(component, "createExperiment");
+    spyOn(component, 'createExperiment');
     htmlElement = fixture.debugElement.query(By.css('.btn.btn-success.pull-right')).nativeElement;
     htmlElement.click();
     expect(component.createExperiment).toHaveBeenCalled();

--- a/frontend/src/app/components/experiments/experiment-retrieve/experiment-retrieve.component.spec.ts
+++ b/frontend/src/app/components/experiments/experiment-retrieve/experiment-retrieve.component.spec.ts
@@ -41,25 +41,25 @@ describe('ExperimentRetrieveComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it("The listExperiments() method should be called if the 'Back' button is clicked", async(() => {
+  it('The listExperiments() method should be called if the \'Back\' button is clicked', async(() => {
 
-    spyOn(component, "listExperiments");
+    spyOn(component, 'listExperiments');
     htmlElement = fixture.debugElement.query(By.css('.btn.btn-lg.btn-danger.back')).nativeElement;
     htmlElement.click();
     expect(component.listExperiments).toHaveBeenCalled();
   }));
 
-  it("The updateExperiment() method should be called if the 'Edit' button is clicked", async(() => {
+  it('The updateExperiment() method should be called if the \'Edit\' button is clicked', async(() => {
 
-    spyOn(component, "updateExperiment");
+    spyOn(component, 'updateExperiment');
     htmlElement = fixture.debugElement.query(By.css('.btn.btn-lg.btn-success')).nativeElement;
     htmlElement.click();
     expect(component.updateExperiment).toHaveBeenCalled();
   }));
 
-  it("The deleteExperiment() method should be called if the 'Delete' button is clicked", async(() => {
+  it('The deleteExperiment() method should be called if the \'Delete\' button is clicked', async(() => {
 
-    spyOn(component, "deleteExperiment");
+    spyOn(component, 'deleteExperiment');
     htmlElement = fixture.debugElement.query(By.css('.btn.btn-lg.btn-danger.delete')).nativeElement;
     htmlElement.click();
     expect(component.deleteExperiment).toHaveBeenCalled();

--- a/frontend/src/app/components/experiments/experiment-update/experiment-update.component.spec.ts
+++ b/frontend/src/app/components/experiments/experiment-update/experiment-update.component.spec.ts
@@ -17,8 +17,8 @@ describe('ExperimentUpdateComponent', () => {
     TestBed.configureTestingModule({
       declarations: [ ExperimentUpdateComponent ],
       imports: [
-        RouterTestingModule, 
-        FormsModule, 
+        RouterTestingModule,
+        FormsModule,
         BrowserModule
       ],
       providers: [
@@ -45,17 +45,17 @@ describe('ExperimentUpdateComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it("The updateExperiment() method should be called if the 'Save changes' button is clicked", async(() => {
+  it('The updateExperiment() method should be called if the \'Save changes\' button is clicked', async(() => {
 
-    spyOn(component, "updateExperiment");
+    spyOn(component, 'updateExperiment');
     htmlElement = fixture.debugElement.query(By.css('.btn.btn-success.pull-right')).nativeElement;
     htmlElement.click();
     expect(component.updateExperiment).toHaveBeenCalled();
   }));
 
-  it("The listExperiments() method should be called if the 'Back' button is clicked", async(() => {
+  it('The listExperiments() method should be called if the \'Back\' button is clicked', async(() => {
 
-    spyOn(component, "listExperiments");
+    spyOn(component, 'listExperiments');
     htmlElement = fixture.debugElement.query(By.css('.btn.btn-lg.btn-danger')).nativeElement;
     htmlElement.click();
     expect(component.listExperiments).toHaveBeenCalled();

--- a/frontend/src/app/components/nav/nav.component.spec.ts
+++ b/frontend/src/app/components/nav/nav.component.spec.ts
@@ -1,7 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NavComponent } from './nav.component';
 import { Router } from '@angular/router';
-import { RouterStub } from  '../../router-stub';
+import { RouterStub } from '../../router-stub';
 import { BrowserModule, By } from '@angular/platform-browser';
 
 describe('NavComponent', () => {
@@ -32,9 +32,9 @@ describe('NavComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it("The logout() method should be called if the 'Log out' button is clicked", async(() => {
+  it('The logout() method should be called if the \'Log out\' button is clicked', async(() => {
 
-    spyOn(component, "logout");
+    spyOn(component, 'logout');
     htmlElement = fixture.debugElement.query(By.css('.btn.btn-danger.float-right.logoutBtn')).nativeElement;
     htmlElement.click();
     expect(component.logout).toHaveBeenCalled();

--- a/frontend/src/app/components/signup/signup.component.spec.ts
+++ b/frontend/src/app/components/signup/signup.component.spec.ts
@@ -55,33 +55,33 @@ describe('SignupComponent', () => {
     expect(component.passwordConfirmation).toEqual('', 'The password confirmation field is not empty.');
   }));
 
-  it("The signup() method should be called if the 'Sign up' button is clicked", async(() => {
-    spyOn(component, "signup");
+  it('The signup() method should be called if the \'Sign up\' button is clicked', async(() => {
+    spyOn(component, 'signup');
     htmlElement = fixture.debugElement.query(By.css('.btn.rounded-btn')).nativeElement;
     htmlElement.click();
     expect(component.signup).toHaveBeenCalled();
   }));
 
-  it("The validation of the signup fields with empty strings should return false.", async(() => {
+  it('The validation of the signup fields with empty strings should return false.', async(() => {
 
-    expect(component.validate()).toBe(false)
+    expect(component.validate()).toBe(false);
   }));
 
-  it("Two non-empty, equal passwords should be considered as a confirmed password.", async(() => {
+  it('Two non-empty, equal passwords should be considered as a confirmed password.', async(() => {
 
     component.user.password = 'password';
     component.passwordConfirmation = 'password';
     expect(component.passwordWasConfirmed()).toBe(true);
   }));
 
-  it("Two different passwords should not be considered as a confirmed password.", async(() => {
+  it('Two different passwords should not be considered as a confirmed password.', async(() => {
 
     component.user.password = 'string1';
     component.passwordConfirmation = 'string2';
-    expect(component.passwordWasConfirmed()).toBe(false)
+    expect(component.passwordWasConfirmed()).toBe(false);
   }));
 
-  it("Two empty passwords should not be considered as a confirmed password.", async(() => {
+  it('Two empty passwords should not be considered as a confirmed password.', async(() => {
 
     component.user.password = '';
     component.passwordConfirmation = '';

--- a/frontend/src/app/components/signup/signup.component.ts
+++ b/frontend/src/app/components/signup/signup.component.ts
@@ -68,8 +68,8 @@ export class SignupComponent implements OnInit {
 
   passwordWasConfirmed() {
 
-    return (this.user.password != null && this.passwordConfirmation != null) 
-    && (this.user.password.length > 0 && this.passwordConfirmation.length > 0) 
+    return (this.user.password != null && this.passwordConfirmation != null)
+    && (this.user.password.length > 0 && this.passwordConfirmation.length > 0)
     && (this.user.password === this.passwordConfirmation);
   }
 }

--- a/frontend/src/app/models/body-part.ts
+++ b/frontend/src/app/models/body-part.ts
@@ -3,7 +3,7 @@ import { Experiment } from './experiment';
 export class BodyPart {
     constructor(
         public id?: number,
-        public bodyParts?: string[],
+        public BodyParts?: string[],  // tslint:disable-line:variable-name
         public experiment_id?: number
     ) { }
 }

--- a/frontend/src/app/models/body-part.ts
+++ b/frontend/src/app/models/body-part.ts
@@ -1,9 +1,9 @@
-import { Experiment } from "./experiment";
+import { Experiment } from './experiment';
 
 export class BodyPart {
     constructor(
         public id?: number,
-        public BodyParts?: string[],
+        public bodyParts?: string[],
         public experiment_id?: number
     ) { }
 }

--- a/frontend/src/app/services/crud.service.ts
+++ b/frontend/src/app/services/crud.service.ts
@@ -12,7 +12,7 @@ export class CrudService {
     USER: 'users',
     EXPERIMENT: 'experiments',
     QUESTIONNAIRE: 'questionnaires',
-    BODYPART : "bodyPart"
+    BODYPART : 'bodyPart'
   };
 
   constructor(private auth: AuthService, private http: HttpClient) {


### PR DESCRIPTION
The frontend still had linting errors. This fixes them.

This adds another instruction to the Travis CI file to check for linting errors by running `ng lint`.