### PR TITLE
Fixed environment references

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,8 @@ before_script:
 # FRONTEND
 # Go to the frontend folder
 - cd ../frontend/
+# Copy environment file
+- cp src/environments/environment.prod.ts src/environments/environment.ts
 # Install the Angular CLI
 - npm install -g angular-cli
 # Install Karma

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
-import { environment } from '../../environments/environment.prod';
+import { environment } from '../../environments/environment';
 import * as moment from 'moment';
 
 @Injectable()

--- a/frontend/src/app/services/crud.service.ts
+++ b/frontend/src/app/services/crud.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { AuthService } from './auth.service';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
-import { environment } from '../../environments/environment.prod';
+import { environment } from '../../environments/environment';
 
 @Injectable()
 export class CrudService {

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  baseUrl: 'http://localhost:8000/'
+  baseUrl: 'http://35.227.42.255:8000/'
 };

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  baseUrl: 'http://35.227.42.255:8000/'
+  baseUrl: 'http://localhost:8000/'
 };

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2,7 +2,7 @@ import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 
 import { AppModule } from './app/app.module';
-import { environment } from './environments/environment.prod';
+import { environment } from './environments/environment';
 
 if (environment.production) {
   enableProdMode();


### PR DESCRIPTION
Fixed an issue with environment file source configuration in three files of the frontend:
    · /src/main.ts
    · /src/app/services/auth.service.ts
    · /src/app/services/crud.service.ts

These files were referencing the *environment.prod.ts* configuration file, thus forcing the application to run in production mode even when the '--prod' flag was not set in the 'ng serve' command.