### PR TITLE
Redirect on experiment delete

### DIFF
--- a/frontend/src/app/components/experiments/experiment-delete/experiment-delete.component.ts
+++ b/frontend/src/app/components/experiments/experiment-delete/experiment-delete.component.ts
@@ -27,6 +27,7 @@ export class ExperimentDeleteComponent implements OnInit {
     .subscribe(
       (res: Response) => {
         this.errorHandler.showInformativeMessage('Successfully deleted experiment.');
+        this.router.navigate(['/experiments']);
       },
       (err: HttpErrorResponse) => {
         this.errorHandler.handleError(err);


### PR DESCRIPTION
Just added redirection on experiment delete, so user is sent back to /experiments instead of being shown "experiment-delete works!".

-S.