### PR TITLE
Add asset upload to GCS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,7 @@ package-lock.json
 
 # secrets
 /frontend/src/environments/environment.ts
+/backend/server/config/cloud.json
+
+# Emacs
+*~

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ before_script:
 - npm install sequelize-cli
 # Copy the config.json file for Travis to a new file with the proper extension
 - cp server/config/config.json.travis server/config/config.json
+# Copy the cloud.json file to Travis as well
+- cp server/config/cloud.json.travis server/config/cloud.json
 ################################################
 # FRONTEND
 # Go to the frontend folder

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,6 +13,7 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
+    "@google-cloud/storage": "^2.3.0",
     "bcrypt-nodejs": "0.0.3",
     "body-parser": "^1.18.3",
     "chai": "^4.1.2",
@@ -21,6 +22,7 @@
     "mocha": "^5.2.0",
     "moment": "^2.22.2",
     "morgan": "^1.9.0",
+    "multer": "^1.4.1",
     "node-fetch": "^2.2.0",
     "nodemailer": "^4.6.4",
     "nodemon": "^1.18.4",

--- a/backend/server/config/cloud.json.travis
+++ b/backend/server/config/cloud.json.travis
@@ -1,0 +1,4 @@
+{
+  "PROJECT_ID": "xxxxxxxxxx",
+  "CLOUD_BUCKET": "xxxxxxxxxxx"
+}

--- a/backend/server/middlewares/files.js
+++ b/backend/server/middlewares/files.js
@@ -1,0 +1,52 @@
+// Multer handles parsing multipart/form-data requests.
+// This instance is configured to store images in memory.
+// This makes it straightforward to upload to Cloud Storage.
+const Multer = require('multer');
+const { Storage } = require('@google-cloud/storage');
+const config = require('../config/cloud');
+
+exports.multer = Multer({
+  storage: Multer.MemoryStorage,
+  limits: {
+    fileSize: 5 * 1024 * 1024, // no larger than 5mb
+  },
+});
+
+const storage = new Storage({
+  projectId: config.PROJECT_ID,
+});
+
+const bucket = storage.bucket(config.CLOUD_BUCKET);
+
+const getPublicUrl = filename => `https://storage.googleapis.com/${config.CLOUD_BUCKET}/${filename}`;
+
+exports.sendUploadToGCS = (req, res, next) => { // eslint-disable-line consistent-return
+  if (!req.file) {
+    return next();
+  }
+
+  const gcsname = Date.now() + req.file.originalname;
+  const file = bucket.file(gcsname);
+
+  const stream = file.createWriteStream({
+    metadata: {
+      contentType: req.file.mimetype,
+    },
+    resumable: false,
+  });
+
+  stream.on('error', (err) => {
+    req.file.cloudStorageError = err;
+    next(err);
+  });
+
+  stream.on('finish', () => {
+    req.file.cloudStorageObject = gcsname;
+    file.makePublic().then(() => {
+      req.file.cloudStoragePublicUrl = getPublicUrl(gcsname);
+      next();
+    });
+  });
+
+  stream.end(req.file.buffer);
+};

--- a/backend/server/routes/index.js
+++ b/backend/server/routes/index.js
@@ -8,6 +8,8 @@ const questionnaireResponsesController = require('../controllers').questionnaire
 const questionnaireQuestionResponsesController = require('../controllers').questionnaireQuestionResponses;
 const participantsController = require('../controllers').participants;
 
+const filesMiddleware = require('../middlewares/files');
+
 module.exports = (app) => {
   app.get('/api', (req, res) => res.status(200).send({
     message: 'Welcome to the GestureWeb Project API!',
@@ -69,6 +71,27 @@ module.exports = (app) => {
   app.get('/api/participants/:id', participantsController.retrieve);
   app.put('/api/participants/:id', participantsController.update);
   app.delete('/api/participants/:id', participantsController.destroy);
+
+  // Route for uploading files.
+  // The HTTP body to this endpoint should be a multipart form with a single field of file type called 'file'.
+  app.post('/api/fileupload',
+    filesMiddleware.multer.single('file'),
+    filesMiddleware.sendUploadToGCS,
+    (req, res) => {
+      // Was an image uploaded? If so, we'll use its public URL
+      // in cloud storage.
+      if (req.file && req.file.cloudStoragePublicUrl) {
+        res.status(201).send({
+          imageUrl: req.file.cloudStoragePublicUrl,
+          status: 200,
+        });
+      } else {
+        res.status(400).send({
+          status: 400,
+          message: 'Error uploading the file.',
+        });
+      }
+    });
 
   // Routes for the bodyParts
   // app.post('/api/bodyParts', bodyPartsController.create);

--- a/backend/server/routes/index.js
+++ b/backend/server/routes/index.js
@@ -73,7 +73,8 @@ module.exports = (app) => {
   app.delete('/api/participants/:id', participantsController.destroy);
 
   // Route for uploading files.
-  // The HTTP body to this endpoint should be a multipart form with a single field of file type called 'file'.
+  // The HTTP body to this endpoint should be a multipart form with a single field of file
+  // type called 'file'.
   app.post('/api/fileupload',
     filesMiddleware.multer.single('file'),
     filesMiddleware.sendUploadToGCS,


### PR DESCRIPTION
This PR adds asset uploads to Google Cloud Storage to the specific bucket.

To run this, you need a bucket in GCS and to add the following to a new file called `cloud.json` in `backend/server/config`:

```
{
    "PROJECT_ID": "{id of the gcloud project}",
    "CLOUD_BUCKET": "{name of your bucket}"
}
```